### PR TITLE
Ping deselected / double-sort Failed Checks

### DIFF
--- a/nerdlets/common/nrqlQueries.js
+++ b/nerdlets/common/nrqlQueries.js
@@ -10,8 +10,8 @@ export const CHECKS_BY_TYPE = `SELECT (sum(syntheticsFailedCheckCount) + sum(syn
 export const HIGH_CHECKS = `SELECT (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) AS 'Total Checks' FROM NrDailyUsage where syntheticsTypeLabel != 'Ping' SINCE 1 month ago facet syntheticsMonitorName, syntheticsMonitorId, consumingAccountName, consumingAccountId limit 50`;
 export const HIGH_LOCATIONS = `SELECT uniqueCount(syntheticsLocationLabel) FROM NrDailyUsage WHERE syntheticsTypeLabel != 'Ping' SINCE 1 day ago FACET syntheticsMonitorName, syntheticsMonitorId, consumingAccountName, consumingAccountId LIMIT 50`;
 
-//failed checks tab
-export const FAILED_CHECKS = `SELECT sum(syntheticsFailedCheckCount)/ (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) * 100 AS 'Failure Rate', sum(syntheticsFailedCheckCount) AS 'Number Failed Checks', (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) AS 'Total Number of Checks' FROM NrDailyUsage where syntheticsTypeLabel != 'Ping' SINCE 1 month ago facet syntheticsMonitorName, syntheticsMonitorId, consumingAccountName, consumingAccountId limit 30`;
+//failed checks tab - fails at 100; limiting to 50
+export const FAILED_CHECKS = `SELECT sum(syntheticsFailedCheckCount)/ (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) * 100 AS 'Failure Rate', sum(syntheticsFailedCheckCount) AS 'Number Failed Checks', (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) AS 'Total Number of Checks' FROM NrDailyUsage where syntheticsTypeLabel != 'Ping' SINCE 1 month ago facet syntheticsMonitorName, syntheticsMonitorId, consumingAccountName, consumingAccountId limit 50`;
 
 // low checks
 export const LOW_CHECKS = `FROM NrDailyUsage SELECT (sum(syntheticsFailedCheckCount) + sum(syntheticsSuccessCheckCount)) * -1 as 'Total Checks' WHERE syntheticsTypeLabel != 'Ping' since 1 month ago FACET syntheticsMonitorName, syntheticsMonitorId, consumingAccountName, consumingAccountId limit 50`;

--- a/nerdlets/common/utils.js
+++ b/nerdlets/common/utils.js
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
-import { NrqlQuery, usePlatformState } from 'nr1';
-import { DEV, STAGING, CROSS_ACCOUNT_CHUNK_SIZE } from '../common/constants';
-import { FAILED_CHECKS } from './nrqlQueries';
+import { useEffect, useState } from "react";
+import { NrqlQuery, usePlatformState } from "nr1";
+import { DEV, STAGING, CROSS_ACCOUNT_CHUNK_SIZE } from "../common/constants";
+import { FAILED_CHECKS } from "./nrqlQueries";
 
 const getMonitors = (query, isRaw = false, accountId) => {
   return NrqlQuery.query({
@@ -16,11 +16,11 @@ const getMonitors = (query, isRaw = false, accountId) => {
         monitorId: result.metadata.groups[2].value,
         accountName: result.metadata.groups[3].value,
         accountId: result.metadata.groups[4].value,
-        ...(result.data[0]['Total Checks'] && {
-          totalChecks: result.data[0]['Total Checks'],
+        ...(result.data[0]["Total Checks"] && {
+          totalChecks: result.data[0]["Total Checks"],
         }),
-        ...(result.data[0]['syntheticsLocationLabel'] && {
-          numLocations: result.data[0]['syntheticsLocationLabel'],
+        ...(result.data[0]["syntheticsLocationLabel"] && {
+          numLocations: result.data[0]["syntheticsLocationLabel"],
         }),
       }));
       monitors.pop();
@@ -32,7 +32,7 @@ const getMonitors = (query, isRaw = false, accountId) => {
         monitorId: result.name[1],
         accountName: result.name[2],
         accountId: result.name[3],
-        failedRate: result.results[0].result,
+        failedRate: Math.round(result.results[0].result * 100) / 100,
         failCount: result.results[1].sum,
         totalChecks: result.results[2].result,
       }));

--- a/nerdlets/home/failedChecks.jsx
+++ b/nerdlets/home/failedChecks.jsx
@@ -23,6 +23,10 @@ import { useGuids } from "../common/utils";
 const FailingChecksData = () => {
   const { monitors, loading } = useGuids(FAILED_CHECKS);
 
+  monitors.sort(function (a, b) {   
+    return (Math.round(b.failedRate * 100) / 100) -  (Math.round(a.failedRate * 100) / 100) || b.failCount - a.failCount;
+});
+
   const renderTable = () => {
     const renderWarning = (failureRate) => {
       if (failureRate > 0.9) {
@@ -59,7 +63,7 @@ const FailingChecksData = () => {
             <TableHeader>
               <TableHeaderCell
                 value={({ item }) => item.monitorName}
-                width="50%"
+                width="40%"
               >
                 Monitor Name
               </TableHeaderCell>
@@ -68,16 +72,16 @@ const FailingChecksData = () => {
               </TableHeaderCell>
               <TableHeaderCell
                 value={({ item }) => item.failedRate}
-                width="10%"
+                width="15%"
               >
                 Failure Rate
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.failCount} width="10%">
+              <TableHeaderCell value={({ item }) => item.failCount} width="13%">
                 Failed Check Count
               </TableHeaderCell>
               <TableHeaderCell
                 value={({ item }) => item.totalChecks}
-                width="10%"
+                width="12%"
               >
                 Total Monthly Checks
               </TableHeaderCell>
@@ -140,10 +144,10 @@ export function FailedChecks() {
       <GridItem columnSpan={8}>
         <></>
       </GridItem>
-      <GridItem columnSpan={12}>
+      <GridItem columnSpan={10}>
         <Card spacingType={[Card.SPACING_TYPE.LARGE]}>
           <CardHeader>
-            <HeadingText>Top Failing Checks</HeadingText>
+            <HeadingText>Top 50 Failing Checks</HeadingText>
             <BlockText>since 1 month ago</BlockText>
           </CardHeader>
           <CardBody>

--- a/nerdlets/home/failedChecks.jsx
+++ b/nerdlets/home/failedChecks.jsx
@@ -24,7 +24,7 @@ const FailingChecksData = () => {
   const { monitors, loading } = useGuids(FAILED_CHECKS);
 
   monitors.sort(function (a, b) {   
-    return (Math.round(b.failedRate * 100) / 100) -  (Math.round(a.failedRate * 100) / 100) || b.failCount - a.failCount;
+    return b.failedRate  -  a.failedRate || b.failCount - a.failCount;
 });
 
   const renderTable = () => {
@@ -97,7 +97,7 @@ const FailingChecksData = () => {
                 <TableRowCell>{item.accountName}</TableRowCell>
                 <TableRowCell>
                   {renderWarning(item.failedRate)} {"   "}
-                  {Math.round(item.failedRate * 100) / 100}%
+                  {item.failedRate}%
                 </TableRowCell>
                 <TableRowCell>{item.failCount.toLocaleString()}</TableRowCell>
                 <TableRowCell>{item.totalChecks.toLocaleString()}</TableRowCell>

--- a/nerdlets/home/index.jsx
+++ b/nerdlets/home/index.jsx
@@ -14,7 +14,7 @@ export default () => {
     });
   }, []);
   return (
-    <Tabs>
+    <Tabs defaultValue="tab-3">
       <TabsItem value="tab-0" label="Usage Overview">
         <Overview />
       </TabsItem>

--- a/nerdlets/home/index.jsx
+++ b/nerdlets/home/index.jsx
@@ -14,7 +14,7 @@ export default () => {
     });
   }, []);
   return (
-    <Tabs defaultValue="tab-3">
+    <Tabs>
       <TabsItem value="tab-0" label="Usage Overview">
         <Overview />
       </TabsItem>

--- a/nerdlets/home/noAlerts.jsx
+++ b/nerdlets/home/noAlerts.jsx
@@ -31,7 +31,6 @@ import { CHUNK_SIZE, ENTITY_MAX } from "../common/constants";
 const NoAlerts = () => {
   const [{ accountId }] = usePlatformState();
   const [types, setTypes] = useState([
-    "Ping",
     "Simple Browser",
     "Scripted API",
     "Scripted Browser",


### PR DESCRIPTION
Updates to High Failure Monitors tab:
* Sets the failed percentage at the object creation on the High Failure tab
* does a double sort on the failures - first by percentage, then highest number of failures first
* Ups the number of Failed Checks in the table to 50 (from 30) and denotes the number in the chart heading

Update to No Alerts Tab:
* removes Ping (free checks) type by default when looking at monitors without alerts