### PR TITLE
fetch monitorType from NG entitySearch query

### DIFF
--- a/nerdlets/common/ngQueries.js
+++ b/nerdlets/common/ngQueries.js
@@ -1,4 +1,4 @@
-import { ngql } from 'nr1';
+import { ngql } from "nr1";
 
 export const generateNoAlertsQuery = (accountId, cursor) => ngql`
 {
@@ -26,7 +26,6 @@ query ($guids: [EntityGuid]!) {
     entities(guids: $guids) {
       ... on SyntheticMonitorEntity {
         monitorId
-        monitorType
       }
       account {
         id


### PR DESCRIPTION
Bug Fix:

Previously, I noticed Ping monitors came back as 'Simple' and so did 'Broken Links' from the Nerdgraph EntitySearch query on the "No Alerts" tab.

Some of the later monitor types (like 'broken links') appear to be part of a larger parent type of monitor (in this case, 'simple').

This meant some of the functions where I fetched the monitor type, it was actually returning the parent monitor type instead. Unfortunately, NRQL queries on NrDailyUsage also return the parent type. 

For this to work properly, I set the monitor type from the first function fetching data `generateNoAlertsQuery()` and carry this monitorType data through the other functions fetching data. 