### PR TITLE
Authorized accounts fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ This project is distributed under the [Apache 2 license](LICENSE).
 
 ## What do you need to get this to work?
 
-The only thing you need is to have Synthetics monitors set up and running.
+* Node version 16
+* Git
+* NR1 CLI installed (notes below)
+* A user with permissions to update Nerdpacks
+* Synthetics monitors set up and running
 
 ## Getting Started
 
@@ -38,16 +42,22 @@ git --version
 npm -v
 ```
 
-2. Install the [NR1 CLI](https://one.newrelic.com/launcher/developer-center.launcher) by going to [the developer center](https://one.newrelic.com/launcher/developer-center.launcher), and following the instructions to install and set up your New Relic development environment. This should take about 5 minutes.
+2. Install the [NR1 CLI](https://one.newrelic.com/launcher/developer-center.launcher) by going to [the developer center](https://one.newrelic.com/launcher/developer-center.launcher), and following the instructions to install and set up your New Relic development environment. This should take about 5 minutes. Make sure you agree to the terms and conditions in this process or the Nerdpack will not build.
+
 3. Execute the following command to clone this repository and run the code locally against your New Relic data:
 
 ```bash
 git clone https://github.com/newrelic-experimental/synthetics-auditor.git
 cd synthetics-auditor
-nr1 nerdpack:serve
+npm install
+nr1 nerdpack:uuid -gf --profile=PROFILE_NAME
+nr1 nerdpack:serve --profile=PROFILE_NAME 
 ```
 
-Visit [https://one.newrelic.com/?nerdpacks=local](https://one.newrelic.com/?nerdpacks=local) to launch your app locally.
+> Note: You can find your profile names by running `nr1 profiles:list`
+
+In the terminal, select the Launcher link to get directed to the Synthetics Auditor app.
+Alternatively, visit [https://one.newrelic.com/?nerdpacks=local](https://one.newrelic.com/?nerdpacks=local) and navigate to Apps -> Synthetics Auditor.
 
 ## Deploying this Nerdpack
 

--- a/nerdlets/common/ngQueries.js
+++ b/nerdlets/common/ngQueries.js
@@ -61,3 +61,13 @@ query ($period: String!) {
   }
 }
 `;
+
+export const FETCH_AUTHORIZED_ACCOUNTS = ngql`
+{
+  actor {
+    accounts(scope: GLOBAL) {
+      id
+    }
+  }
+}
+`;

--- a/nerdlets/home/highestChecks.jsx
+++ b/nerdlets/home/highestChecks.jsx
@@ -91,6 +91,7 @@ const ChecksByMonitorPeriod = () => {
   useEffect(async () => {
     setLoading(true);
     fetchMonitorsByPeriod();
+    setLoading(false)
   }, [period, accountId]);
 
   const fetchMonitorsByPeriod = () => {

--- a/nerdlets/home/highestChecks.jsx
+++ b/nerdlets/home/highestChecks.jsx
@@ -217,16 +217,16 @@ const MostLocations = () => {
             <TableHeader>
               <TableHeaderCell
                 value={({ item }) => item.monitorName}
-                width="50%"
+                width="70%"
               >
                 Monitor Name
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.accountId} width="30%">
+              <TableHeaderCell value={({ item }) => item.accountId} width="18%">
                 Consuming Account Name
               </TableHeaderCell>
               <TableHeaderCell
                 value={({ item }) => item.numLocations}
-                width="20%"
+                width="12%"
               >
                 Location Count
               </TableHeaderCell>
@@ -301,7 +301,7 @@ export function HighestChecks() {
         </GridItem>
 
         {/* row 2; 2 items */}
-        <GridItem columnSpan={6}>
+        <GridItem columnSpan={8}>
           <Card spacingType={[Card.SPACING_TYPE.LARGE]}>
             <CardHeader>
               <HeadingText>Monitors with Most Locations</HeadingText>
@@ -314,7 +314,7 @@ export function HighestChecks() {
         </GridItem>
 
         {/* row 3; 1 item */}
-        <GridItem columnSpan={6}>
+        <GridItem columnSpan={4}>
           <Card spacingType={[Card.SPACING_TYPE.LARGE]}>
             <CardHeader>
               <HeadingText>Monitors by Frequency</HeadingText>

--- a/nerdlets/home/lowestChecks.jsx
+++ b/nerdlets/home/lowestChecks.jsx
@@ -221,16 +221,16 @@ const LeastLocations = () => {
             <TableHeader>
               <TableHeaderCell
                 value={({ item }) => item.monitorName}
-                width="50%"
+                width="70%"
               >
                 Monitor Name
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.accountId} width="30%">
+              <TableHeaderCell value={({ item }) => item.accountId} width="18%">
                 Consuming Account Name
               </TableHeaderCell>
               <TableHeaderCell
                 value={({ item }) => item.numLocations}
-                width="20%"
+                width="12%"
               >
                 Location Count
               </TableHeaderCell>
@@ -307,7 +307,7 @@ export function LowestChecks() {
           </Card>
         </GridItem>
         {/* row 2; 2 items */}
-        <GridItem columnSpan={6}>
+        <GridItem columnSpan={8}>
           <Card spacingType={[Card.SPACING_TYPE.LARGE]}>
             <CardHeader>
               <HeadingText>Monitors with Least Locations</HeadingText>
@@ -319,7 +319,7 @@ export function LowestChecks() {
           </Card>
         </GridItem>
         {/* row 3; 1 item */}
-        <GridItem columnSpan={6}>
+        <GridItem columnSpan={4}>
           <Card spacingType={[Card.SPACING_TYPE.LARGE]}>
             <CardHeader>
               <HeadingText>Monitors by Frequency</HeadingText>

--- a/nerdlets/home/noAlerts.jsx
+++ b/nerdlets/home/noAlerts.jsx
@@ -26,7 +26,7 @@ import {
   generateNoAlertsQuery,
   FETCH_MONITOR_INFO_NO_ALERTS,
 } from "../common/ngQueries";
-import { CHUNK_SIZE, ENTITY_MAX } from "../common/constants";
+import { CHUNK_SIZE, ENTITY_MAX, DEV, STAGING } from "../common/constants";
 
 const NoAlerts = () => {
   const [{ accountId }] = usePlatformState();
@@ -101,7 +101,7 @@ const NoAlerts = () => {
 
   const getMons = async (accountId) => {
     const guids = await getGuids(accountId);  //array of guids + mon types
-    
+
     const results = [];
     // reassociate the results back to the monitorType
     const getTypeByGuid = (resultGuid) => { 
@@ -161,6 +161,13 @@ const NoAlerts = () => {
       const monitor = monsById[facet.name];
       const totalChecks = facet.results[0].result;
       monitor.totalChecks = totalChecks;
+      if (DEV) {
+        monitor.permalink = `https://dev-one.newrelic.com/redirect/entity/${monitor.guid}`;
+      } else if (STAGING) {
+        monitor.permalink = `https://staging-one.newrelic.com/redirect/entity/${monitor.guid}`;
+      } else {
+        monitor.permalink = `https://one.newrelic.com/redirect/entity/${monitor.guid}`;
+      }
       aggCount += totalChecks;
     }
     monitors.sort((a, b) => {
@@ -212,7 +219,9 @@ const NoAlerts = () => {
         )}
 
         {/* Monitors Loaded */}
+        {console.log("loading and monitors", loading, monitors)}
         {!loading && monitors.length > 0 && (
+          
           <Table items={monitors} style={{ height: "500px" }}>
             <TableHeader>
               <TableHeaderCell value={({ item }) => item.name}>

--- a/nerdlets/home/noAlerts.jsx
+++ b/nerdlets/home/noAlerts.jsx
@@ -224,16 +224,16 @@ const NoAlerts = () => {
           
           <Table items={monitors} style={{ height: "500px" }}>
             <TableHeader>
-              <TableHeaderCell value={({ item }) => item.name}>
+              <TableHeaderCell value={({ item }) => item.name} width="50%">
                 Monitor Name (Monitor Count: {monitors.length})
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.monitorType}>
+              <TableHeaderCell value={({ item }) => item.monitorType} width="16%">
                 Monitor Type
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.account.name}>
+              <TableHeaderCell value={({ item }) => item.account.name} width="16%">
                 Consuming Account
               </TableHeaderCell>
-              <TableHeaderCell value={({ item }) => item.totalChecks}>
+              <TableHeaderCell value={({ item }) => item.totalChecks} width="17%">
                 Monthly Checks
               </TableHeaderCell>
             </TableHeader>

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "0bfdee48-7564-4b5c-94a0-3d1454c10dfe",
+  "id": "f2b58ea9-9727-4b25-8a5c-dd859073b77f",
   "displayName": "Synthetics Auditor",
   "description": "Find synthetics monitors that may need attention: over/under utilized, aren't sync'd with alerts, 100% fail rate, too many locations, running too often"
 }


### PR DESCRIPTION
FIX: Chart loading issue for some users; user can only query Nerdgraph on Authorized Accounts

FIX: No Alerts tab was not correctly creating the link for the monitors without alerts

UI Improvement: Wider widths for longer monitor names to avoid names showing up as only '...'

Readme update: added some additional notes for installation