### PR TITLE
Filter out Ping Monitors in the 'by Frequency' charts

### DIFF
--- a/nerdlets/home/highestChecks.jsx
+++ b/nerdlets/home/highestChecks.jsx
@@ -105,9 +105,10 @@ const ChecksByMonitorPeriod = () => {
           const unfilteredMonitors =
             response.data.actor.entitySearch.results.entities;
           unfilteredMonitors.forEach((unfilteredMonitor) => {
+            let flatTags = unfilteredMonitor.tags.map(({values}) => values)
+            
             if (
-              unfilteredMonitor.tags.find((element) => element == "Ping") ==
-              undefined
+              flatTags.find((element) => element == "Ping") == undefined
             ) {
               filteredMonitors.push(unfilteredMonitor);
             }

--- a/nerdlets/home/lowestChecks.jsx
+++ b/nerdlets/home/lowestChecks.jsx
@@ -101,15 +101,14 @@ const ChecksByMonitorPeriod = () => {
           const filteredMonitors = [];
           const unfilteredMonitors =
             response.data.actor.entitySearch.results.entities;
-
-          unfilteredMonitors.forEach((unfilteredMonitor) => {
-            if (
-              unfilteredMonitor.tags.find((element) => element == "Ping") ==
-              undefined
-            ) {
-              filteredMonitors.push(unfilteredMonitor);
-            }
-          });
+            unfilteredMonitors.forEach((unfilteredMonitor) => {
+              let flatTags = unfilteredMonitor.tags.map(({values}) => values)
+              if (
+                flatTags.find((element) => element == "Ping") == undefined
+              ) {
+                filteredMonitors.push(unfilteredMonitor);
+              }
+            });
           return filteredMonitors;
         })
         .then((data) => {


### PR DESCRIPTION
The previous logic did not correctly filter out ping-type monitors. This method allows all the tag values to be plucked out and then Ping types are removed.

Thanks to Shamika for pointing out this bug!